### PR TITLE
Fix typo: it's CONAN_RUN_TESTS, not CONAN_RUN_TEST

### DIFF
--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -427,7 +427,7 @@ or declared in command line when invoking :command:`conan install` to reduce the
 
 .. code-block:: bash
 
-    $ conan install . -e CONAN_RUN_TEST=0
+    $ conan install . -e CONAN_RUN_TESTS=0
 
 See how to retrieve the value with :ref:`tools.get_env() <tools_get_env>` and check a use case
 with :ref:`a header only with unit tests recipe <header_only_unit_tests_tip>` while cross building.


### PR DESCRIPTION
Documentation was inconsistent about which name was correct. Per [discussion in #conan](https://cpplang.slack.com/archives/C41CWV9HA/p1587398710012500) and [uses in conan-center-index](https://github.com/conan-io/conan-center-index/search?q=CONAN_RUN_TESTS&unscoped_q=CONAN_RUN_TESTS) the plural is correct.